### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,9 @@ source:
   sha256: 70867a59e6b67e7720958ceb14476a2a00f34c12ad03680faed3163ed70138e2
 
 build:
-  entry_points:
-    - lightning = lightning.app.cli.lightning_cli:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -40,7 +38,6 @@ test:
     - lightning
   commands:
     - pip check
-    - LIGHTING_TESTING=1 lightning --help
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,40 +23,17 @@ requirements:
     - setuptools
     - wheel
   run:
-    - arrow <3.0,>=1.2.0
-    - backoff <4.0,>=2.2.1
-    - beautifulsoup4 <6.0,>=4.8.0
-    - click <10.0
-    - croniter <1.5.0,>=1.3.0
-    - dateutils <2.0
-    - deepdiff <8.0,>=5.7.0
-    - fastapi <2.0,>=0.92.0
     - fsspec <2025.0,>=2022.5.0
-    - inquirer <5.0,>=2.10.0
-    - jinja2 <5.0
-    - lightning-cloud >=0.5.38
     - lightning-utilities <2.0,>=0.8.0
     - numpy <3.0,>=1.17.2
     - packaging <25.0,>=20.0
-    - psutil <7.0
-    - pydantic <2.2.0,>=1.7.4
     - python >=3.8
-    - python-multipart <2.0,>=0.0.5
     - pytorch <4.0,>=1.12.0
     - pytorch-lightning
     - pyyaml <8.0,>=5.4
-    - requests <4.0
-    - rich <15.0,>=12.3.0
-    - starlette
-    - starsessions <2.0,>=1.2.1
     - torchmetrics <3.0,>=0.7.0
     - tqdm <6.0,>=4.57.0
-    - traitlets <7.0,>=5.3.0
     - typing-extensions <6.0,>=4.0.0
-    - urllib3 <4.0
-    - uvicorn <2.0
-    - websocket-client <3.0
-    - websockets <13.0
 
 test:
   imports:


### PR DESCRIPTION
Removes dependencies that are no longer necessary. As of Lightning 2.1, the "app" part and its dependencies are no longer required, and can be installed via the extra instead. 

Fixes https://github.com/Lightning-AI/pytorch-lightning/issues/19083

@Borda 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
